### PR TITLE
Update ZenFS

### DIFF
--- a/core/kernel/package.json
+++ b/core/kernel/package.json
@@ -164,7 +164,7 @@
     "@zenfs/core": "^1.6.6",
     "@zenfs/dom": "^1.0.7",
     "@zenfs/emscripten": "^1.0.0",
-    "@zenfs/zip": "^0.5.2",
+    "@zenfs/archives": "^1.0.0",
     "@zip.js/zip.js": "^2.7.52",
     "ansi-escape-sequences": "^6.2.3",
     "chalk": "^5.3.0",

--- a/core/kernel/package.json
+++ b/core/kernel/package.json
@@ -163,7 +163,7 @@
     "@xterm/xterm": "^5.5.0",
     "@zenfs/core": "^1.6.6",
     "@zenfs/dom": "^1.0.7",
-    "@zenfs/emscripten": "^0.1.2",
+    "@zenfs/emscripten": "^1.0.0",
     "@zenfs/zip": "^0.5.2",
     "@zip.js/zip.js": "^2.7.52",
     "ansi-escape-sequences": "^6.2.3",

--- a/core/kernel/pnpm-lock.yaml
+++ b/core/kernel/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
+      '@zenfs/archives':
+        specifier: ^1.0.0
+        version: 1.0.0(@zenfs/core@1.6.6)
       '@zenfs/core':
         specifier: ^1.6.6
         version: 1.6.6
@@ -94,9 +97,6 @@ importers:
       '@zenfs/emscripten':
         specifier: ^1.0.0
         version: 1.0.0(@zenfs/core@1.6.6)
-      '@zenfs/zip':
-        specifier: ^0.5.2
-        version: 0.5.2(@zenfs/core@1.6.6)
       '@zip.js/zip.js':
         specifier: ^2.7.52
         version: 2.7.53
@@ -1351,6 +1351,12 @@ packages:
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
+  '@zenfs/archives@1.0.0':
+    resolution: {integrity: sha512-PpnWHnUYjf02DwS3Cpl+cTG01njITve54xFdnro4AbJfk9mLHXotqw1ejvRlRHeiBirLROs2bIpbCnQ4PbhbsA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@zenfs/core': ^1.4.2
+
   '@zenfs/core@1.6.6':
     resolution: {integrity: sha512-dciOscuQfElSyS2pZJwhJ0EoKNxYsn227hwXmZi+gcAmaupcHdBuAS52QA8iYmZR58PjhOljRAJAhWsXFpMsdQ==}
     engines: {node: '>= 16'}
@@ -1367,13 +1373,6 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       '@zenfs/core': ^1.3.0
-
-  '@zenfs/zip@0.5.2':
-    resolution: {integrity: sha512-1rrYJ7SWiIqa2+TCoaOY5QjTScMhPim0odpbuwrzukIW+NAR3ZGqkuMVc7/hlkdj2nxpGuvini53vWyWNwdhWQ==}
-    engines: {node: '>= 18'}
-    deprecated: '@zenfs/zip and @zenfs/iso have been merged into @zenfs/archives and will no longer be updated.'
-    peerDependencies:
-      '@zenfs/core': ^1.0.11
 
   '@zip.js/zip.js@2.7.53':
     resolution: {integrity: sha512-G6Bl5wN9EXXVaTUIox71vIX5Z454zEBe+akKpV4m1tUboIctT5h7ID3QXCJd/Lfy2rSvmkTmZIucf1jGRR4f5A==}
@@ -3698,11 +3697,11 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  utilium@1.1.0:
-    resolution: {integrity: sha512-02uMD58LHEacpSkzx46JZ0FDvFGpSGUYN6mSHY9wqNUi4sZVNzDdUXa9unLLCj5pRxK28HcYqqe/iQToBpmxTw==}
-
   utilium@1.1.1:
     resolution: {integrity: sha512-uNwrjhLA+KN5/EuDJaofvRerLffPSQ1aj6uot21tCwiU2oHKWHU2F3xW+wETgjJ3JFqDIloY6zSutQRmTbjAVw==}
+
+  utilium@1.1.2:
+    resolution: {integrity: sha512-RWgBwS+PsbXmcOA+Fa+rmnB7asPBSco4MRmeP1Zul6Qz1tworLixbTCcl8vhGNKdzL1S/VWnwku7AwT62iFofQ==}
 
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
@@ -5028,6 +5027,12 @@ snapshots:
 
   '@zeit/schemas@2.36.0': {}
 
+  '@zenfs/archives@1.0.0(@zenfs/core@1.6.6)':
+    dependencies:
+      '@zenfs/core': 1.6.6
+      fflate: 0.8.2
+      utilium: 1.1.2
+
   '@zenfs/core@1.6.6':
     dependencies:
       '@types/node': 22.10.1
@@ -5050,12 +5055,6 @@ snapshots:
     dependencies:
       '@zenfs/core': 1.6.6
       utilium: 1.1.1
-
-  '@zenfs/zip@0.5.2(@zenfs/core@1.6.6)':
-    dependencies:
-      '@zenfs/core': 1.6.6
-      fflate: 0.8.2
-      utilium: 1.1.0
 
   '@zip.js/zip.js@2.7.53': {}
 
@@ -7523,13 +7522,13 @@ snapshots:
       is-typed-array: 1.1.13
       which-typed-array: 1.1.15
 
-  utilium@1.1.0:
+  utilium@1.1.1:
     dependencies:
       eventemitter3: 5.0.1
     optionalDependencies:
       '@xterm/xterm': 5.5.0
 
-  utilium@1.1.1:
+  utilium@1.1.2:
     dependencies:
       eventemitter3: 5.0.1
     optionalDependencies:

--- a/core/kernel/pnpm-lock.yaml
+++ b/core/kernel/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(@zenfs/core@1.6.6)
       '@zenfs/emscripten':
-        specifier: ^0.1.2
-        version: 0.1.2(@zenfs/core@1.6.6)
+        specifier: ^1.0.0
+        version: 1.0.0(@zenfs/core@1.6.6)
       '@zenfs/zip':
         specifier: ^0.5.2
         version: 0.5.2(@zenfs/core@1.6.6)
@@ -241,7 +241,7 @@ importers:
         version: 2.1.5(@types/node@22.9.1)(playwright@1.49.0)(typescript@5.6.3)(vite@6.0.1(@types/node@22.9.1)(sass-embedded@1.81.0)(yaml@2.6.1))(vitest@2.1.5)
       '@vitest/coverage-v8':
         specifier: ^2.1.2
-        version: 2.1.5(@vitest/browser@2.1.5(@types/node@22.9.1)(playwright@1.49.0)(typescript@5.6.3)(vite@6.0.1(@types/node@22.9.1)(sass-embedded@1.81.0)(yaml@2.6.1))(vitest@2.1.5))(vitest@2.1.5(@types/node@22.9.1)(@vitest/browser@2.1.5)(@vitest/ui@2.1.5)(jsdom@25.0.1(canvas@2.11.2))(msw@2.6.5(@types/node@22.9.1)(typescript@5.6.3))(sass-embedded@1.81.0))
+        version: 2.1.5(@vitest/browser@2.1.5)(vitest@2.1.5)
       '@vitest/ui':
         specifier: ^2.1.2
         version: 2.1.5(vitest@2.1.5)
@@ -1362,11 +1362,11 @@ packages:
     peerDependencies:
       '@zenfs/core': ^1.6.4
 
-  '@zenfs/emscripten@0.1.2':
-    resolution: {integrity: sha512-lcCSIc/8JaQ8tPhUmGUBe/aUiw4ajD6bKkd3ktS9AQ6TNzW1S5zsO8ocGlX61lnD3KoV1MFJAKbWEaLq4EA9dA==}
+  '@zenfs/emscripten@1.0.0':
+    resolution: {integrity: sha512-QvxoqmXNRnVRnKlliDNu/hBaIMeDYGkP4PHoxOzeVyY0J3Mah/I0wzG1S+atWynld6g7Y+H64HwsOjrlMPY5wA==}
     engines: {node: '>= 18'}
     peerDependencies:
-      '@zenfs/core': ^1.0.4
+      '@zenfs/core': ^1.3.0
 
   '@zenfs/zip@0.5.2':
     resolution: {integrity: sha512-1rrYJ7SWiIqa2+TCoaOY5QjTScMhPim0odpbuwrzukIW+NAR3ZGqkuMVc7/hlkdj2nxpGuvini53vWyWNwdhWQ==}
@@ -4870,7 +4870,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@2.1.5(@vitest/browser@2.1.5(@types/node@22.9.1)(playwright@1.49.0)(typescript@5.6.3)(vite@6.0.1(@types/node@22.9.1)(sass-embedded@1.81.0)(yaml@2.6.1))(vitest@2.1.5))(vitest@2.1.5(@types/node@22.9.1)(@vitest/browser@2.1.5)(@vitest/ui@2.1.5)(jsdom@25.0.1(canvas@2.11.2))(msw@2.6.5(@types/node@22.9.1)(typescript@5.6.3))(sass-embedded@1.81.0))':
+  '@vitest/coverage-v8@2.1.5(@vitest/browser@2.1.5)(vitest@2.1.5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -5046,10 +5046,10 @@ snapshots:
       fake-indexeddb: 6.0.0
       file-system-access: 1.0.4
 
-  '@zenfs/emscripten@0.1.2(@zenfs/core@1.6.6)':
+  '@zenfs/emscripten@1.0.0(@zenfs/core@1.6.6)':
     dependencies:
       '@zenfs/core': 1.6.6
-      utilium: 1.1.0
+      utilium: 1.1.1
 
   '@zenfs/zip@0.5.2(@zenfs/core@1.6.6)':
     dependencies:

--- a/core/kernel/src/tree/lib/commands/index.ts
+++ b/core/kernel/src/tree/lib/commands/index.ts
@@ -25,7 +25,7 @@ import * as zipjs from '@zip.js/zip.js'
 
 import { createCredentials, Fetch, InMemory, resolveMountConfig, useCredentials, Stats } from '@zenfs/core'
 import { IndexedDB } from '@zenfs/dom'
-import { Zip } from '@zenfs/zip'
+import { Zip } from '@zenfs/archives'
 
 import {
   KernelEvents,


### PR DESCRIPTION
This PR migrates `@zenfs/zip` to `@zenfs/archives` and updates `@zenfs/emscripten` to `^1.0.0` in order to receive future updates.